### PR TITLE
Fix: Update `onClose` handler to cancel drag-and-drop in `PopConfirm` modal

### DIFF
--- a/src/components/common/PopConfirm.tsx
+++ b/src/components/common/PopConfirm.tsx
@@ -21,7 +21,7 @@ const PopConfirm = () => {
   }, [clearConfirm, onCancel])
 
   return (
-    <Modal open={isActive} onClose={clearConfirm}>
+    <Modal open={isActive} onClose={handleCancel}>
       <Stack
         sx={{
           width: 400,


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Updated the `onClose` handler of the `Modal` component in `PopConfirm` to call `handleCancel` instead of `clearConfirm`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PopConfirm.tsx</strong><dd><code>Update `onClose` handler in `PopConfirm` component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/common/PopConfirm.tsx
<li>Changed the <code>onClose</code> handler of the <code>Modal</code> component from <code>clearConfirm</code> <br>to <code>handleCancel</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/UCTalent/uc-ats-react-app/pull/33/files#diff-72af339e8035e7e6564f16625c0994ee34a9c02ba3957846d3812cce6f4129f3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

