### PR TITLE
Fix navigation logic for login paths in PublicRoute component

### DIFF
--- a/src/components/common/PublicRoute.tsx
+++ b/src/components/common/PublicRoute.tsx
@@ -18,7 +18,7 @@ const PublicRoute: FC<IProps> = ({ children }) => {
     }
 
     if (currentUser.isLoggedIn) {
-      if (pathname === "/login") {
+      if (pathname.startsWith("/login")) {
         navigate("/")
       }
       return


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed a bug in the `PublicRoute` component where the navigation condition was updated to check if the pathname starts with "/login" instead of being exactly "/login".
- This change ensures that users are redirected to the home page when they are logged in and attempt to access any login-related path.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PublicRoute.tsx</strong><dd><code>Fix navigation condition for login path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/common/PublicRoute.tsx
<li>Modified the condition to check if the pathname starts with "/login".<br> <li> Ensures navigation to the home page when logged in and accessing any <br>login-related path.<br>


</details>
    

  </td>
  <td><a href="https://github.com/UCTalent/uc-ats-react-app/pull/52/files#diff-045425a4cae4efc6dff6a99d93131eaae5ceccb94debef6ffd081ad9e191563b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

