### PR TITLE
Fix candidate status logic in CandidateStageColumnCard component

### DIFF
--- a/src/components/subsections/job-detail/CandidateStageColumnCard.tsx
+++ b/src/components/subsections/job-detail/CandidateStageColumnCard.tsx
@@ -25,9 +25,9 @@ const CandidateStageColumnCard: React.FC<TypeProps> = ({ candidate, jobId, statu
   const navigate = useNavigate()
 
   useEffect(() => {
-    if (!candidateId) return
+    if (!candidateId || candidateId !== candidate.talent.id) return
     setTalentOverview((prev) => ({ ...prev, status }))
-  }, [setTalentOverview, status, candidateId])
+  }, [setTalentOverview, status, candidateId, candidate.talent.id])
 
   const handleCardClick = useCallback(() => {
     setTalentOverview((prev) => ({ ...prev, status }))


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed the logic in the `useEffect` hook to ensure that the candidate status is only set when `candidateId` matches `candidate.talent.id`.
- Updated the dependency array of the `useEffect` hook to include `candidate.talent.id` for accurate effect execution.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CandidateStageColumnCard.tsx</strong><dd><code>Fix candidate status logic in useEffect hook</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/subsections/job-detail/CandidateStageColumnCard.tsx
<li>Added a condition to check if <code>candidateId</code> matches <code>candidate.talent.id</code>.<br> <li> Updated dependency array in <code>useEffect</code> to include <code>candidate.talent.id</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/UCTalent/uc-ats-react-app/pull/71/files#diff-5159e3ea9978cb49ce5e0cb1bb3ab01abfad3aba9e754515de1654c0f3354da2">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

