### PR TITLE
Fix job status key from `hire` to `hired` in constants

### DIFF
--- a/src/constants/JOB.ts
+++ b/src/constants/JOB.ts
@@ -64,6 +64,6 @@ export const dndSceneInitial = {
   screening: [],
   interview: [],
   offer: [],
-  hire: [],
+  hired: [],
   failed: [],
 }


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Corrected the job status key from `hire` to `hired` in the `dndSceneInitial` object within the `JOB.ts` file.
- This change ensures consistency in job status terminology across the application.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>JOB.ts</strong><dd><code>Correct job status key from `hire` to `hired`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/constants/JOB.ts
<li>Changed the key <code>hire</code> to <code>hired</code> in the <code>dndSceneInitial</code> object.<br> <li> This update reflects a correction in the job status terminology.<br>


</details>
    

  </td>
  <td><a href="https://github.com/UCTalent/uc-ats-react-app/pull/74/files#diff-c48f7884f35291ad149e573a63a8552f53b20b2b16bccfc13ec9974bfe38b62f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

