### PR TITLE
Fix candidate status update from "hire" to "hired" in Kanban board

### DIFF
--- a/src/hooks/useDndKanbanBoard.ts
+++ b/src/hooks/useDndKanbanBoard.ts
@@ -128,7 +128,7 @@ const useDndKanbanBoard = <ICardData>(
       setMovedCard(null)
     }
 
-    if (["hire", "failed"].includes(toColumnId)) {
+    if (["hired", "failed"].includes(toColumnId)) {
       configConfirm({
         title: `Change status`,
         //@ts-ignore


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed a typo in the `useDndKanbanBoard` hook to correctly update candidate status from "hire" to "hired".
- Ensures that the status change confirmation dialog is triggered correctly for the "hired" status.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useDndKanbanBoard.ts</strong><dd><code>Fix typo in column ID for status change handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/hooks/useDndKanbanBoard.ts
<li>Fixed a typo in the column ID check from "hire" to "hired".<br> <li> Ensures correct status change handling for candidates.<br>


</details>
    

  </td>
  <td><a href="https://github.com/UCTalent/uc-ats-react-app/pull/75/files#diff-94b94e67d7924aa121b34f9194b19bafc5ad7dec16f1f5846698cea60d257d91">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

