### PR TITLE
Fix total page calculation for empty jobs case in TheHomePage

### DIFF
--- a/src/pages/TheHomePage.tsx
+++ b/src/pages/TheHomePage.tsx
@@ -29,7 +29,7 @@ const TheHomePage = () => {
         <TheJobsList data={data} />
         <FooterPagination
           page={page}
-          totalPage={data?.business?.jobs?.totalPages}
+          totalPage={data?.business?.jobs?.totalPages || 1}
           onPrevious={onPreviousPage}
           onNext={onNextPage}
         />


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed an issue in `TheHomePage.tsx` where the `totalPage` for the `FooterPagination` component could be undefined or null when there are no jobs. A default value of 1 is now provided to ensure proper pagination behavior.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TheHomePage.tsx</strong><dd><code>Fix total page calculation for empty jobs case</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pages/TheHomePage.tsx
<li>Fixed the <code>totalPage</code> calculation for the <code>FooterPagination</code> component.<br> <li> Added a default value of 1 for <code>totalPage</code> when <br><code>data?.business?.jobs?.totalPages</code> is undefined or null.<br>


</details>
    

  </td>
  <td><a href="https://github.com/UCTalent/uc-ats-react-app/pull/90/files#diff-7f0ec2238ccc884fb339ad0c67c61c976248561bef5ad4b0d935429e4739e438">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

